### PR TITLE
ci: set git identity for release tag; add manual dispatch

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -20,13 +20,15 @@ name: release-publish
 on:
   pull_request:
     types: [closed]
+  workflow_dispatch: {} # manual re-run (reads the version from the manifest on main)
 
 jobs:
   build:
-    # Only when a PR labeled `release` is actually merged.
+    # A merged PR labeled `release`, or a manual dispatch.
     if: >-
-      github.event.pull_request.merged == true &&
-      contains(github.event.pull_request.labels.*.name, 'release')
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
+       contains(github.event.pull_request.labels.*.name, 'release'))
     runs-on: ubuntu-latest
     permissions:
       contents: write # push the release tag
@@ -38,12 +40,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
           fetch-depth: 0
 
       - name: Resolve version + create tag
         id: resolve
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           TAG="v$(jq -r '."."' .release-please-manifest.json)"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           git tag -a "${TAG}" -m "${TAG}"


### PR DESCRIPTION
Publish failed at the tag step with `empty ident name` — no git user configured. Sets the github-actions bot identity before tagging.

Also adds `workflow_dispatch` so the publish can be re-run manually (reads the version from `.release-please-manifest.json` on main), since the `pull_request` trigger won't re-fire for an already-merged release PR.