### PR TITLE
ci: build from the release tag, not branch HEAD

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -56,6 +56,10 @@ jobs:
             git tag -a "${TAG}" -m "${TAG}"
             git push origin "${TAG}"
           fi
+          # Build from the tag so hatch-vcs produces the exact release version.
+          # (On a manual re-run, main may have advanced past the tag, which would
+          # otherwise yield a rejected dev/local version like 0.16.2.dev1+g….)
+          git checkout -q "refs/tags/${TAG}"
 
       - name: Set up conda (conda-build + anaconda-client)
         uses: conda-incubator/setup-miniconda@v3


### PR DESCRIPTION
Re-dispatched publish built `0.16.2.dev1+g…` (rejected by PyPI as a local version) because it checked out main HEAD, which had advanced past `v0.16.1`. hatch-vcs needs to build exactly on the tag. Adds `git checkout refs/tags/<tag>` before the build.